### PR TITLE
PRIVMSG Refactor - WIP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ SRCS		=	Server.cpp \
 				Commands/Pass.cpp \
 				Commands/User.cpp \
 				Commands/Nick.cpp \
-				Commands/Topic.cpp 
+				Commands/Topic.cpp \
+				Commands/PrivMsg.cpp 
 
 HEADERS		=	includes/Server.hpp \
 				includes/AClient.hpp \
@@ -26,7 +27,8 @@ HEADERS		=	includes/Server.hpp \
 				includes/Commands/Kick.hpp \
 				includes/Commands/Pass.hpp \
 				includes/Commands/User.hpp \
-				includes/Commands/Nick.hpp
+				includes/Commands/Nick.hpp \
+				includes/Commands/PrivMsg.hpp
 
 SRCS_DIR    =   ./src/
 

--- a/includes/AClient.hpp
+++ b/includes/AClient.hpp
@@ -31,11 +31,14 @@ public:
     const std::string& getIp( void ) const;
     const std::string  getOrigin( void ) const;
     const int& getSocketFd( void ) const;
-    const int& getQueueSize( void ) const;
+    const bool& getPurge( void ) const;
+    int getQueueSize( void ) const;
+    const std::string& getFirstMsg( void) const;
 
     /* Setters */
     void setNick( const std::string& );
     void setPass( const std::string& );
     void setUser( const std::string& );
+    void setPurge( const bool& purge );
 };
 

--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -16,7 +16,6 @@ private:
     std::map<std::string, AClient*>  _clients;
 
     /* PRIVATE Methods */
-    void _broadcastJoin( const std::string& nick , const std::string& joinMsg );
     void _sendNames( AClient* client );
 
 public:
@@ -28,7 +27,7 @@ public:
     void kickUser( const std::string& nick, const std::string& msg );
     void addInvitation( const std::string& nick );
     void removeInvitation( const std::string& nick );
-    void addMsg( const std::string& msg );
+    void addMsg( const std::string& cli , const std::string& msg );
 
     /* Getters */
     bool  isInvited( const std::string& nick ) const;

--- a/includes/Commands/PrivMsg.hpp
+++ b/includes/Commands/PrivMsg.hpp
@@ -1,0 +1,13 @@
+# pragma once
+
+#include "ICommand.hpp"
+#include "../AClient.hpp"
+#include "../Server.hpp"
+
+class PrivMsg: public ICommand {
+public:
+    PrivMsg( Server& ircServ );
+    ~PrivMsg( void );
+    void execute( AClient *, const std::string & rawCommand );
+    void clearCmd( void );
+};

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -25,6 +25,7 @@
 #include "Commands/Pass.hpp"
 #include "Commands/User.hpp"
 #include "Commands/Nick.hpp"
+#include "Commands/PrivMsg.hpp"
 #include "utils.hpp"
 #include "colors.hpp"
 #include "replies.hpp"
@@ -90,6 +91,7 @@ public:
     friend class User;
     friend class Nick;
     friend class Join;
+    friend class PrivMsg;
     friend void execCommand( Server& ircServ , std::string clientMsg , AClient* cli );
 };
 

--- a/includes/replies.hpp
+++ b/includes/replies.hpp
@@ -13,6 +13,8 @@
 
 # define ERR_INVITEONLYCHAN( arg ) std::string(":0.0.0.0 473 ") + arg + std::string(" :Cannot join channel (+i) - invite only\r\n")
 # define ERR_BADCHANNELKEY( arg ) std::string(":0.0.0.0 475 ") + arg + std::string(" :Cannot join channel (+k) - bad key\r\n")
+
+# define ERR_ERRONEUSNICKNAME( arg ) std::string(":0.0.0.0 432 ") + arg + std::string(" :Erroneous Nickname\r\n")
 # define RPL_TOPIC( arg , topic ) std::string(":0.0.0.0 332 ") + arg + std::string(" :") + topic + std::string("\r\n")
 # define RPL_TOPICWHOTIME( arg ) std::string(":0.0.0.0 333 ") + arg + std::string("\r\n")
 # define RPL_NAMREPLY( arg , users ) std::string(":0.0.0.0 353 ") + arg + std::string( " :" ) + users + std::string("\r\n")

--- a/src/AClient.cpp
+++ b/src/AClient.cpp
@@ -17,7 +17,7 @@ void AClient::addMsg( const std::string& msg) { _msgs.push( msg ); }
 
 void AClient::sendMSg( void ) {
     if (_msgs.size()) {
-        std::string msg = _msgs.front();
+        std::string msg = getFirstMsg();
         send(_socketFd , msg.c_str() , msg.length() , MSG_DONTWAIT);
         _msgs.pop();
     }
@@ -38,10 +38,18 @@ const std::string AClient::getOrigin( void ) const {
 
 const int& AClient::getSocketFd( void ) const { return( _socketFd ); }
 
+const bool& AClient::getPurge( void ) const { return _purge; }
+
+int AClient::getQueueSize( void ) const { return _msgs.size(); }
+
+const std::string& AClient::getFirstMsg( void) const { return _msgs.front(); }
+
 void AClient::setNick( const std::string& nick ) { _nick = nick; }
 
 void AClient::setPass( const std::string& pass ) { _pass = pass; }
 
 void AClient::setUser( const std::string& user ) { _user = user; }
+
+void AClient::setPurge( const bool& purge ) { _purge = purge; }
 
 

--- a/src/Commands/Join.cpp
+++ b/src/Commands/Join.cpp
@@ -13,8 +13,6 @@ static strPair findChanKey( std::vector<std::string> tokens ) {
 
     if (tokens.size() == 2)
         keyPair.second = *(++it);
-    else
-        keyPair.second = "";
     return ( keyPair );
 }
 

--- a/src/Commands/Kick.cpp
+++ b/src/Commands/Kick.cpp
@@ -52,7 +52,7 @@ void Kick::execute( AClient* client, const std::string& rawCommand ) {
         + " " + _kickedNick + " :";
         kickResponse += _reason.empty() ? "No Reason\r\n" : _reason + "\r\n";
         _channel->kickUser( _kickedNick, kickResponse );
-        _channel->addMsg( kickResponse );
+        _channel->addMsg( _kickedNick , kickResponse );
     } catch ( const std::exception& e ) {
         _client->addMsg( e.what() );
     }

--- a/src/Commands/Nick.cpp
+++ b/src/Commands/Nick.cpp
@@ -8,9 +8,24 @@ Nick::~Nick( void ) {
 
 }
 
+static bool nickAuthorizedChars(const std::string& nick) {
+    bool isAuthorized = true;
+    std::string authorizedChars("qazwsxedcrfvtgbyhnujmikolpQAZWSXEDCRFVTGBYHNUJMIKOLP`|^_-{}[]\\1234567890");
+
+    if ( !std::isalpha(nick[0]) || nick.find_first_not_of(authorizedChars) != std::string::npos )
+        isAuthorized = false;
+    return (isAuthorized);
+}
+
 void Nick::execute( AClient* const client, const std::string & rawCommand ){
     PreClient *target = dynamic_cast<PreClient *>(client);
-    client->setNick(rawCommand);
+    if (nickAuthorizedChars(rawCommand))
+        client->setNick(rawCommand);
+    else {
+        client->addMsg(ERR_ERRONEUSNICKNAME(client->getNick() + " " + rawCommand));
+        if (target)
+            client->setPurge(true);
+    }
     if ( target && !client->getNick().empty() && !client->getUser().empty() && !client->getPass().empty() ) {
         _ircServ._addClient(client);
         _ircServ._clients.erase(client->getSocketFd());

--- a/src/Commands/PrivMsg.cpp
+++ b/src/Commands/PrivMsg.cpp
@@ -1,0 +1,74 @@
+#include "Commands/PrivMsg.hpp"
+
+PrivMsg::PrivMsg( Server& ircServ ) : ICommand( ircServ ) {
+
+}
+
+PrivMsg::~PrivMsg( void ) {
+
+}
+
+static std::string  findTargetName( const std::string& full_command ) {
+    std::string target;
+    std::vector< std::string > split_command = utils::split( full_command , " ");
+    std::vector< std::string >::iterator split_it = split_command.begin();
+
+    target = *split_it;
+    return ( target );
+}
+
+static std::string  findContent( const std::string& full_command ) {
+    std::string content;
+    std::vector< std::string > split_command = utils::split( full_command , " ");
+    std::vector< std::string >::iterator split_it = split_command.begin();
+
+    content = *(*(++split_it)).erase((*split_it).begin()) + " ";
+    while ( split_it  != split_command.end()) {
+        content += *split_it + " ";
+        split_it++;
+    }
+    return ( content );
+}
+
+static bool isChannel(const std::string& target) {
+    bool isChan = true;
+
+    if (target[0] != '#' && target[0] != '&')
+        isChan = false;
+    return isChan;
+}
+
+void PrivMsg::execute( AClient* const client, const std::string& rawCommand ){
+    std::string target = findTargetName(rawCommand);
+    std::string content = findContent(rawCommand);
+    std::string msg = client->getOrigin() + " PRIVMSG " + target + " :" + content + "\r\n";
+
+    if (isChannel(target)) {
+        std::map<const std::string, Channel*>::iterator chan = _ircServ._channels.find(target);
+        if (chan != _ircServ._channels.end())
+            chan->second->addMsg(client->getNick() , msg);
+        else
+            client->addMsg(ERR_NOSUCHCHANNEL(_ircServ.getIp() , target));
+    } else {
+        AClient* cli = _ircServ._findClientByNick(target);
+        if (cli)
+            cli->addMsg(msg);
+        else
+            client->addMsg(ERR_NOSUCHNICK(_ircServ.getIp() , target));
+    }
+    // allowed chars in nick [a-z A-Z `|^_-{}[]\ 0-9] and must start with letter
+
+    /*
+    Channels names are strings (beginning with a '&' or '#' character) of
+    length up to 200 characters.  Apart from the the requirement that the
+    first character being either '&' or '#'; the only restriction on a
+    channel name is that it may not contain any spaces (' '), a control G
+    (^G or ASCII 7), or a comma (',' which is used as a list item
+    separator by the protocol).
+   */
+
+  // if no channel ERR_NOSUCHCHANNEL()
+
+}
+
+void PrivMsg::clearCmd( void ){};

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -20,6 +20,7 @@ void Server::_initCmds( void ) {
     _cmds.insert( std::pair<const std::string, ICommand*>( "PASS", new Pass( *this ) ) );
     _cmds.insert( std::pair<const std::string, ICommand*>( "USER", new User( *this ) ) );
     _cmds.insert( std::pair<const std::string, ICommand*>( "NICK", new Nick( *this ) ) );
+    _cmds.insert( std::pair<const std::string, ICommand*>( "PRIVMSG", new PrivMsg( *this ) ) );
 }
 
 /**
@@ -107,6 +108,11 @@ void Server::_handlePreClientReg() {
 
 void Server::_handleClientSend(const int& socket) {
     AClient &cli= *_clients[socket];
+    if (cli.getQueueSize()) {
+        std::cout << "[ " << GREEN << "ATTEMPTING TO SEND - " << cli.getNick() << " " << RESET << "]" << std::endl;
+        std::cout << cli.getFirstMsg() << std::endl;
+        std::cout << "[ " << GREEN << "END ATTEMPT SEND " << RESET << "]\n" << std::endl;
+    }
     cli.sendMSg();
 }
 
@@ -128,7 +134,7 @@ void Server::_handleClientRecv(const int& socket) {
         } while (rcv > 0);
 
         std::cout << "[" << BLUE << "RECEIVED" << RESET << "]" <<std::endl << fullMsg << std::endl;
-        std::cout <<"[" << BLUE << "END RECEIVE" << RESET << "]" << std::endl;
+        std::cout <<"[" << BLUE << "END RECEIVE" << RESET << "]\n" << std::endl;
 
         execCommand( *this , fullMsg , _clients[socket]);
     } else if ( rcv == 0) {
@@ -174,7 +180,7 @@ void execCommand( Server& ircServ , std::string clientMsg , AClient* cli) {
     for (std::vector<std::string>::iterator it = commands.begin(); it != commands.end(); it++) {
         std::pair<std::string , std::string> cmdParts = extractCommand(*it);
 
-        if ( isValidCommand(cmdParts.first) )
+        if ( isValidCommand(cmdParts.first) && !cli->getPurge() )
             ircServ._cmds[cmdParts.first]->execute( cli , cmdParts.second);
     }
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -32,5 +32,7 @@ std::vector<std::string> utils::split( std::string str , std::string delm) {
             list.push_back( token );
         str.erase(0, pos + delm.length());
     }
+    if (!str.empty())
+        list.push_back(str);
     return ( list );
 }

--- a/testing/splitTest.cpp
+++ b/testing/splitTest.cpp
@@ -3,26 +3,22 @@
 #include <iostream>
 using namespace std;
 
-std::vector<std::string> splitDelim( std::string str , std::string delim) {
-	std::string strSection;
-	std::vector<std::string> sections;
-
-	size_t pos = 0;
-	while ((pos = str.find(delim)) != std::string::npos) {
-		strSection = str.substr(0, pos);
-		sections.push_back( strSection );
-		str.erase(0, pos + delim.length());
-	}
-	pos = str.find(delim);
-	strSection = str.substr(0, pos);
-	sections.push_back(strSection);
-    return ( sections );
-	
+std::vector<std::string> splitDelim( std::string str , std::string delm) {
+size_t pos = 0;
+    std::string token;
+    std::vector<std::string> list;
+    while ( ( pos = str.find( delm ) ) != std::string::npos ) {
+        token = str.substr(0, pos);
+        if ( !token.empty() )
+            list.push_back( token );
+        str.erase(0, pos + delm.length());
+    }
+    return ( list );	
 }
 
 int main() {
 
-    string x = "JOIN akjsndkajsndkjansd";
+    string x = "#saha";
 
     cout << splitDelim(x , " ").size() << endl;
 


### PR DESCRIPTION
The server now checks if the nickname has proper format and can now message users in a channel. still WIP.

Changes:
	- Nick checks if the format is correct before setting the nickname.
	- utils::split fixed minor bug
	- removed Channel::_broadcastMessage since addMsg does same functionality
	- modified Channel::addMsg to take nick of user to exclude from broadcast
	- add PRIVMSG functionality (still WIP, minor bugs to fix)
	- added new setters and getter to AClient
**NOTE: This is pushed with some minor bugs that still need to be fixed. ALL comments from previous PR have been resolved with this push.**