### PR TITLE
MSG Refactor Completed with some extra functionality and bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ SRCS		=	Server.cpp \
 				Commands/User.cpp \
 				Commands/Nick.cpp \
 				Commands/Topic.cpp \
-				Commands/PrivMsg.cpp 
+				Commands/PrivMsg.cpp \
+				Commands/Ping.cpp 
 
 HEADERS		=	includes/Server.hpp \
 				includes/AClient.hpp \
@@ -28,7 +29,9 @@ HEADERS		=	includes/Server.hpp \
 				includes/Commands/Pass.hpp \
 				includes/Commands/User.hpp \
 				includes/Commands/Nick.hpp \
-				includes/Commands/PrivMsg.hpp
+				includes/Commands/PrivMsg.hpp \
+				includes/Commands/Ping.hpp \
+				includes/replies.hpp
 
 SRCS_DIR    =   ./src/
 

--- a/includes/Commands/Ping.hpp
+++ b/includes/Commands/Ping.hpp
@@ -1,0 +1,14 @@
+# pragma once
+
+#include "ICommand.hpp"
+#include "../AClient.hpp"
+#include "../Server.hpp"
+
+class Ping: public ICommand {
+public:
+    Ping();
+    Ping( Server& ircServ );
+    ~Ping();
+    void execute( AClient *, const std::string & rawCommand );
+    void clearCmd( void );
+};

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -26,6 +26,7 @@
 #include "Commands/User.hpp"
 #include "Commands/Nick.hpp"
 #include "Commands/PrivMsg.hpp"
+#include "Commands/Ping.hpp"
 #include "utils.hpp"
 #include "colors.hpp"
 #include "replies.hpp"
@@ -71,6 +72,7 @@ public:
     /* Methods */
     void init( void );
     void run( void );
+    bool nickInUse ( const std::string& nick ) const;
     void exit( void );
 
     /* Getters */
@@ -92,6 +94,7 @@ public:
     friend class Nick;
     friend class Join;
     friend class PrivMsg;
+    friend class Ping;
     friend void execCommand( Server& ircServ , std::string clientMsg , AClient* cli );
 };
 

--- a/includes/replies.hpp
+++ b/includes/replies.hpp
@@ -13,6 +13,7 @@
 
 # define ERR_INVITEONLYCHAN( arg ) std::string(":0.0.0.0 473 ") + arg + std::string(" :Cannot join channel (+i) - invite only\r\n")
 # define ERR_BADCHANNELKEY( arg ) std::string(":0.0.0.0 475 ") + arg + std::string(" :Cannot join channel (+k) - bad key\r\n")
+# define ERR_NICKNAMEINUSE( arg ) std::string(":0.0.0.0 433 nick ") + arg + std::string(" :Nickname is already in use\r\n")
 
 # define ERR_ERRONEUSNICKNAME( arg ) std::string(":0.0.0.0 432 ") + arg + std::string(" :Erroneous Nickname\r\n")
 # define RPL_TOPIC( arg , topic ) std::string(":0.0.0.0 332 ") + arg + std::string(" :") + topic + std::string("\r\n")

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -5,9 +5,32 @@ Client::Client( const AClient& preClient ) : AClient( preClient ) {
 	std::string welcome_001 = ":" + _ip + " 001 " + getNick() + " :Welcome to FT_IRC " + getNick() + "!" + getUser() + "@" + getIp() + "\r\n";
 	std::string your_host = ":" + _ip + " 002 " + getNick() + " :Your host is 127.0.0.1, running version idk anymore\r\n";
 	std::string server_created = ":" + _ip + " 003 " + getNick() + " :Server created sometime this year.\r\n";
+    std::string modes = ":" + _ip + " 004 " + getNick() + " " + _ip + " V-unknown i iotk ko\r\n";
+    std::string motdStart = ":" + _ip + " 375 " + getNick() + " :Message of the Day\r\n";
+    std::string motd = ":" + _ip + " 372 " + getNick() + " :" + " ▄▄▄▄    ▒█████   ███▄    █   ██████  ▒█████   ██▓ ██▀███     ▓█████  ██▓     ██▓     ██▓ ▒█████  ▄▄▄█████▓\r\n";
+	std::string motd1= ":" + _ip + " 372 " + getNick() + " :" + "▓█████▄ ▒██▒  ██▒ ██ ▀█   █ ▒██    ▒ ▒██▒  ██▒▓██▒▓██ ▒ ██▒   ▓█   ▀ ▓██▒    ▓██▒    ▓██▒▒██▒  ██▒▓  ██▒ ▓▒\r\n";
+	std::string motd2= ":" + _ip + " 372 " + getNick() + " :" + "▒██▒ ▄██▒██░  ██▒▓██  ▀█ ██▒░ ▓██▄   ▒██░  ██▒▒██▒▓██ ░▄█ ▒   ▒███   ▒██░    ▒██░    ▒██▒▒██░  ██▒▒ ▓██░ ▒░\r\n";
+	std::string motd3= ":" + _ip + " 372 " + getNick() + " :" + "▒██░█▀  ▒██   ██░▓██▒  ▐▌██▒  ▒   ██▒▒██   ██░░██░▒██▀▀█▄     ▒▓█  ▄ ▒██░    ▒██░    ░██░▒██   ██░░ ▓██▓ ░ \r\n";
+	std::string motd4= ":" + _ip + " 372 " + getNick() + " :" + "░▓█  ▀█▓░ ████▓▒░▒██░   ▓██░▒██████▒▒░ ████▓▒░░██░░██▓ ▒██▒   ░▒████▒░██████▒░██████▒░██░░ ████▓▒░  ▒██▒ ░ \r\n";
+	std::string motd5= ":" + _ip + " 372 " + getNick() + " :" + "░▒▓███▀▒░ ▒░▒░▒░ ░ ▒░   ▒ ▒ ▒ ▒▓▒ ▒ ░░ ▒░▒░▒░ ░▓  ░ ▒▓ ░▒▓░   ░░ ▒░ ░░ ▒░▓  ░░ ▒░▓  ░░▓  ░ ▒░▒░▒░   ▒ ░░   \r\n";
+	std::string motd6= ":" + _ip + " 372 " + getNick() + " :" + "▒░▒   ░   ░ ▒ ▒░ ░ ░░   ░ ▒░░ ░▒  ░ ░  ░ ▒ ▒░  ▒ ░  ░▒ ░ ▒░    ░ ░  ░░ ░ ▒  ░░ ░ ▒  ░ ▒ ░  ░ ▒ ▒░     ░    \r\n";
+	std::string motd7= ":" + _ip + " 372 " + getNick() + " :" + " ░    ░ ░ ░ ░ ▒     ░   ░ ░ ░  ░  ░  ░ ░ ░ ▒   ▒ ░  ░░   ░       ░     ░ ░     ░ ░    ▒ ░░ ░ ░ ▒    ░      \r\n";
+	std::string motd8= ":" + _ip + " 372 " + getNick() + " :" + " ░          ░ ░           ░       ░      ░ ░   ░     ░           ░  ░    ░  ░    ░  ░ ░      ░ ░           \r\n";
+	std::string motd9= ":" + _ip + " 372 " + getNick() + " :" + "      ░                                                                                                    \r\n";
+    std::string motdEnd = ":" + _ip + " 376 " + getNick() + " :End of /MOTD command.\r\n";
+    std::string notice = ":" + _ip + " NOTICE " + getNick() + " :hope you enjoy the server like we enjoyed the project\r\n";
+    std::string mode = getOrigin() + " MODE " + getNick() + " :+i\r\n";
+    std::string whoIsUser = ":" + _ip + " 311 " + getNick() + " " + getUser() + " " + getIp() + " * :" + getUser() + "\r\n";
+    std::string whoIsServer = ":" + _ip + " 312 " + getNick() + " " + getUser() + " " + getIp() + " :1337 h4x0r w0rld\r\n";
     this->addMsg(welcome_001);
     this->addMsg(your_host);
     this->addMsg(server_created);
+    this->addMsg(modes);
+    this->addMsg(motdStart + motd + motd1 + motd2 + motd3 + motd4 + motd5 + motd6 + motd7 + motd8 + motd9 + motdEnd);
+    this->addMsg(notice);
+    this->addMsg(mode);
+    this->addMsg(whoIsUser);
+    this->addMsg(whoIsServer);
 }
 
 Client::~Client( void ) {

--- a/src/Commands/Pass.cpp
+++ b/src/Commands/Pass.cpp
@@ -12,8 +12,8 @@ void Pass::execute( AClient* const client, const std::string & rawCommand ){
     PreClient *target = dynamic_cast<PreClient *>(client);
     client->setPass(rawCommand);
     if ( target && !client->getPass().empty() && !client->getNick().empty() && !client->getUser().empty() ) {
-        _ircServ._addClient(client);
         _ircServ._clients.erase(client->getSocketFd());
+        _ircServ._addClient(client);
         delete client;
 	}
 }

--- a/src/Commands/Ping.cpp
+++ b/src/Commands/Ping.cpp
@@ -1,0 +1,11 @@
+#include "Commands/Ping.hpp"
+
+Ping::Ping( Server& ircServ ) : ICommand( ircServ ) {}
+
+Ping::~Ping( void ) {
+
+}
+void Ping::execute( AClient* client, const std::string & rawCommand ) {
+    client->addMsg( ":" + _ircServ.getIp() + " PONG " + _ircServ.getIp() + " :" + rawCommand + "\r\n" );
+};
+void Ping::clearCmd( void ){};

--- a/src/Commands/PrivMsg.cpp
+++ b/src/Commands/PrivMsg.cpp
@@ -21,12 +21,12 @@ static std::string  findContent( const std::string& full_command ) {
     std::string content;
     std::vector< std::string > split_command = utils::split( full_command , " ");
     std::vector< std::string >::iterator split_it = split_command.begin();
+    
+    content = *(++split_it);
+    content.erase(content.begin());
+    while ( ++split_it  != split_command.end())
+        content += " " + *split_it;
 
-    content = *(*(++split_it)).erase((*split_it).begin()) + " ";
-    while ( split_it  != split_command.end()) {
-        content += *split_it + " ";
-        split_it++;
-    }
     return ( content );
 }
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -21,6 +21,7 @@ void Server::_initCmds( void ) {
     _cmds.insert( std::pair<const std::string, ICommand*>( "USER", new User( *this ) ) );
     _cmds.insert( std::pair<const std::string, ICommand*>( "NICK", new Nick( *this ) ) );
     _cmds.insert( std::pair<const std::string, ICommand*>( "PRIVMSG", new PrivMsg( *this ) ) );
+    _cmds.insert( std::pair<const std::string, ICommand*>( "PING", new Ping( *this ) ) );
 }
 
 /**
@@ -143,7 +144,7 @@ void Server::_handleClientRecv(const int& socket) {
 }
 
 AClient* Server::_findClientByNick( const std::string& nick ) const {
-    for ( std::map<int, AClient*>::const_iterator it; it != _clients.end(); it++ ) {
+    for ( std::map<int, AClient*>::const_iterator it = _clients.begin(); it != _clients.end(); it++ ) {
         if ( it->second->getNick() == nick )
             return ( it->second );
     }
@@ -163,7 +164,7 @@ static std::pair<std::string const , std::string> extractCommand( std::string ra
 
 static bool isValidCommand( std::string cmd ) {
     bool isValid = false;
-    std::string cmdList[] = {"JOIN" , "INVITE" , "KICK" , "MODE" , "PASS", "TOPIC", "USER" , "PRIVMSG" , "NOTICE" , "NICK"};
+    std::string cmdList[] = {"JOIN" , "INVITE" , "KICK" , "MODE" , "PASS", "TOPIC", "USER" , "PRIVMSG" , "NOTICE" , "NICK" , "PING" };
     for (size_t i = 0; i < sizeof(cmdList)/sizeof(cmdList[0]); i++)
     {
         if ( !cmdList[i].compare(cmd) ) {
@@ -193,6 +194,16 @@ void Server::_addClient( const AClient* client ) {
 void Server::_addChannel( const std::string& name , const std::string& topic ) {
 	Channel *newChan = new Channel( name , topic );
 	_channels.insert( std::make_pair( name , newChan ) );
+}
+
+bool Server::nickInUse ( const std::string& nick ) const {
+    bool nickInUse = false;
+
+    for (std::map<int, AClient*>::const_iterator it = _clients.begin(); it != _clients.end(); it++) {
+        if (!(*it).second->getNick().compare(nick))
+            nickInUse = true;
+    }
+    return (nickInUse);
 }
 
 // void Server::_removeClient( void ) {}


### PR DESCRIPTION
This is completion to the previous PR, it is no longer a WIP. Messages are sent and received as expected. registration now checks for in use nicknames. the server will now respond to PING commands from the client keeping the connection active.

Changes:
	- fix messages not being sent in the correct format in PRIVMSG
	- handling PING from the client to keep the connection active
	- fix Pass:execute bug where client was being deleted after beign created
	- add Server::nickInUse function to check if a nickname is already used on the server
	- check if nick in use inside Nick::execute to allow setting the nickname or send error
	- fix Server::_findClientByNick segfault, it variable was not being initalized
	- add connection messages to the client