### PR TITLE
Fixed a bug in mode command

### DIFF
--- a/includes/Commands/DCC.hpp
+++ b/includes/Commands/DCC.hpp
@@ -1,0 +1,15 @@
+# pragma once
+
+#include "ICommand.hpp"
+#include "../AClient.hpp"
+#include "../Server.hpp"
+
+typedef std::pair<std::string , std::string> strPair;
+
+class DCC : public ICommand {
+public:
+    DCC( Server& ircServ );
+    ~DCC();
+    void execute( AClient *, const std::string & rawCommand );
+    void clearCmd( void );
+};

--- a/includes/Commands/Mode.hpp
+++ b/includes/Commands/Mode.hpp
@@ -19,7 +19,6 @@ class Mode: public ICommand {
 private:
     Channel* _chan;
     AClient* _client;
-    std::map<char, bool>    _isExecuted;
     std::map<char, modePtr> _mPtr;
 
     bool inviteMode( bool, std::string& arg );

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -11,7 +11,6 @@
 #include <sstream>
 #include <cstring>
 #include <vector>
-#include <csignal>
 
 #include "AClient.hpp"
 #include "Client.hpp"
@@ -76,8 +75,8 @@ public:
     void init( void );
     void run( void );
     bool nickInUse ( const std::string& nick ) const;
+    void exit( void );
     void removeChannel( const std::string& );
-    void exit( int sigNum );
 
     /* Getters */
     const int& getSockFd(void) const;

--- a/includes/utils.hpp
+++ b/includes/utils.hpp
@@ -5,7 +5,7 @@
 #include <sstream>
 
 namespace utils {
-void trim( std::string& str );
+void trim( std::string& str, const std::string& delm );
 std::vector<std::string> split( std::string str , std::string delm);
 template <typename T> std::string numToA(T num){
     std::stringstream ss;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -385,9 +385,19 @@ void Server::_removeChannel( const std::string& name ) {
  * dynamic memory allocated.
  * 
  */
-void Server::exit( int sigNum ) {
-    if (sigNum == SIGINT)
-        _serverEnd = true;
+void Server::exit( void ) {
+    std::map<int, AClient*>::iterator client_it;
+    std::map<const std::string, Channel*>::iterator chan_it;
+    std::map<const std::string, ICommand*>::iterator cmd_it;
+
+    for (client_it = _clients.begin() ; client_it != _clients.end() ; client_it++)
+        delete _clients[client_it->first];
+
+    for (chan_it = _channels.begin() ; chan_it != _channels.end() ; chan_it++)
+        delete _channels[chan_it->first];
+
+    for (cmd_it = _cmds.begin() ; cmd_it != _cmds.end() ; cmd_it++)
+        delete _cmds[cmd_it->first];
 }
 
 void Server::removeChannel( const std::string& chanName ) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: kamin <kamin@student.42abudhabi.ae>        +#+  +:+       +#+        */
+/*   By: ommohame < ommohame@student.42abudhabi.ae> +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/12 18:23:28 by kamin             #+#    #+#             */
-/*   Updated: 2023/08/30 19:03:53 by kamin            ###   ########.fr       */
+/*   Updated: 2023/08/18 17:52:35 by ommohame         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,36 +28,20 @@ bool validParams( int ac, char **av ) {
     return ( valid_params );
 }
 
-
-Server* serv;
-
-static void sigHandler(int sigNum) {
-    serv->exit(sigNum);
-}
-
 bool IRCserver( int port, std::string const & pass ) {
     Server ircserver = Server( port, pass );
-    serv = &ircserver;
     try {
         ircserver.init();
     } catch ( std::exception const & e ) {
         std::cerr << "[" << e.what() << "]" << std::endl;
     }
     ircserver.run();
+    // ircserver.end();
 
     return ( true );
 }
 
 int main( int ac, char **av ) {
-    struct sigaction sigIntHandler;
-
-   sigIntHandler.sa_handler = sigHandler;
-   sigemptyset(&sigIntHandler.sa_mask);
-   sigIntHandler.sa_flags = 0;
-
-    if (sigaction(SIGINT, &sigIntHandler, NULL) == -1)
-        std::cout << "problem with handler" << std::endl; 
-        
     if ( validParams( ac, av )) {
         IRCserver( atoi( av[1] ) , av[2] );
     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,25 +1,13 @@
 #include "utils.hpp"
 
-void utils::trim( std::string& str ) {
-    for (std::string::iterator i = str.begin(); i != str.end(); i++)
-    {
-        if ( std::isspace(*i) || !std::isprint(*i) ) {
-            str.erase(i);
-            i = str.begin();
-        }
-        else
-        break;
-    }
-
-    for (std::string::iterator i = str.end(); i != str.begin(); i--)
-    {
-        if ( std::isspace(*i) || !std::isprint(*i) ) {
-            str.erase(i);
-            i = str.end();
-        }
-        else
-        break;
-    }
+void utils::trim( std::string& str, const std::string& delm ) {
+    size_t start = str.find_first_not_of( delm );
+    size_t end = str.find_last_not_of( delm );
+    if ( start == std::string::npos )
+        start = 0;
+    if ( end == std::string::npos )
+        end = str.length();
+    str = str.substr( start, end - start + 1 );
 }
 
 std::vector<std::string> utils::split( std::string str , std::string delm) {


### PR DESCRIPTION
# Description:
- Fixed a bug in mode command where if there was no arguments it wouldn't send the response, because `utils::trim()` would throw an exception.

## Changes:
- Changed `utils::trim()` to take the delimiter.
- Changed the `utils::trim()` logic so it's easier to understand what's happening and prevent it from throwing an exception
- Removed `isExecuted` from mode since it's up to the server to implement it.
